### PR TITLE
Fixing autoload.

### DIFF
--- a/src/Bhutanio/BEncode/BEncode.php
+++ b/src/Bhutanio/BEncode/BEncode.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bhutanio;
+namespace Bhutanio\BEncode;
 
 /**
  * PHP Library for decoding and encoding BitTorrent BEncoded data


### PR DESCRIPTION
The autoload settings / namespace structure / folder structure are not correct. Composer cannot autoload this package without changes.

Since the folder path is `src/Bhutanio/BEncode` the namespace for a psr-0 package has to be `Bhutanio\BEncode` and the full class name has to be `Bhutanio\BEncode\BEncode`.

If this was not your intention then perhaps you should remove the `BEncode` folder and place `BEncode.php` directly into `src/Bhutanio` which would also fix the problem.
