### PR TITLE
Make single torrent filelist consistent with multi file torrents

### DIFF
--- a/src/Bhutanio/BEncode/BEncode.php
+++ b/src/Bhutanio/BEncode/BEncode.php
@@ -182,7 +182,7 @@ class BEncode {
 		{
 			$FileCount = 1;
 			$TotalSize = $data['info']['length'];
-			$FileList[]= array($data['info']['length'], $data['info']['name']);
+			$FileList[]= array('size'=>$data['info']['length'], 'name'=>$data['info']['name']);
 		} else { // Multiple file mode
 			$FileNames = array();
 			$TotalSize = 0;


### PR DESCRIPTION
Files in single file torrents were coming out like `[5, 'a']` rather than `['size'=>5,'name'=>'a']` in a multi file torrent